### PR TITLE
Fix/provider brick typo

### DIFF
--- a/bricks/flutter_clean_base/__brick__/{{project_name.snakeCase()}}/lib/core/arch/provider/base_provider_state.dart
+++ b/bricks/flutter_clean_base/__brick__/{{project_name.snakeCase()}}/lib/core/arch/provider/base_provider_state.dart
@@ -22,7 +22,7 @@ abstract class BaseProviderState<P extends BaseProvider,
       },
       lazy: lazyProvider,
       child: Builder(
-        builder: (ctx) {
+        builder: (context) {
           initParams(context);
           return buildWidget(context);
         },


### PR DESCRIPTION
- wrong BuildContext provided in base_provider_state.dart